### PR TITLE
Merge into main

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # SwiftMQTTAsync
 
-SwiftMQTTAsync, as the name suggests, is an async MQTT client library for swift. The library works on macOS and linux and uses swift-nio under the hood. This package is currenlty in ealry-ish developement and currently only supports MQTTv3.1.1.
+SwiftMQTTAsync, as the name suggests, is an async MQTT client library for swift. The library works on macOS and linux and uses swift-nio under the hood. This package is currenlty in ealry-ish developement and supports both v3.1.1 (release 0.2.0) and v5 (release 1.0.0-beta).
 New features are constantly being added and are usually listed under the repo issues.
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -8,13 +8,69 @@ New features are constantly being added and are usually listed under the repo is
 ## Installation
 
 Add this to `package.swift` under `dependencies`
+
 ```swift
 .package(url: "https://github.com/LukaAlhonen/SwiftMQTTAsync.git", from: "<version>"),
 ```
 
-## Basic usage
+## Example usage
+
+### v1.0.0b (MQTTv5 + v3)
+
+Sample v5 subscriber
+
+```swift
+let client = MQTTClientV5(
+    clientId: "test-sub", host: "localhost", port: 1883, config: Config())
+
+try! await client.connect()
+
+try! await client.subscribe(to: [TopicFilter(topic: "test/topic", qos: .AtMostOnce)])
+
+for await event in client.eventStream {
+    switch event {
+    case .received(let packet):
+        switch packet {
+        case .publish(let publish):
+            let topic = publish.variableHeader.topicName
+            let qos = publish.qos
+            let rawPayload = publish.payload.content
+            let message = String(bytes: rawPayload, encoding: .utf8)
+            print("Received message: \(message ?? "") on topic: \(topic), with qos: \(qos)")
+        default:
+            print("Received: \(packet.inner().toString())")
+        }
+    case .send(let packet):
+        print("Sent: \(packet.toString())")
+    case .error(let error):
+        print("Error: \(error)")
+    case .info(let message):
+        print("Info: \(message)")
+    case .warning(let warning):
+        print("Warning: \(warning)")
+    }
+}
+
+await client.stop()
+```
+
+Sample v5 publisher
+
+```swift
+let client = MQTTClientV5(
+    clientId: "test-pub", host: "localhost", port: 1883, config: Config())
+
+try! await client.connect()
+
+try! await client.publish(message: "hello", qos: .AtMostOnce, topic: "test/topic")
+
+await client.stop()
+```
+
+### v0.2.0 (MQTTv3 only)
 
 Sample subscriber
+
 ```swift
 let client = MQTTClient(host: "localhost", port: 1883, config: Config(keepAlive: 30, maxRetries: 5))
 try! await client.connect()
@@ -33,6 +89,7 @@ for try await event in await packet.eventStream {
 ```
 
 Sample publisher
+
 ```swift
 let client = MQTTClient(host: "localhost", port: 1883, config: Config())
 try! await clent.connect()

--- a/Sources/SwiftMQTTAsync/MQTTClient/Config.swift
+++ b/Sources/SwiftMQTTAsync/MQTTClient/Config.swift
@@ -4,15 +4,23 @@ public struct Config: Sendable {
     public let keepAlive: UInt16
     public let pingTimeout: UInt16
     public let connTimeout: UInt16
-    public let maxRetries: UInt16 // max connect retries
+    public let maxRetries: UInt16  // max connect retries
     public let cleanSession: Bool
+    public let subscribeTimeout: UInt16
+    public let publishTimeout: UInt16
 
-    public init(keepAlive: UInt16 = 60, pingTimeout: UInt16 = 5, connTimeout: UInt16 = 30, maxRetries: UInt16 = 0, cleanSession: Bool = true) {
+    public init(
+        keepAlive: UInt16 = 60, pingTimeout: UInt16 = 5, connTimeout: UInt16 = 30,
+        maxRetries: UInt16 = 0, cleanSession: Bool = true, subscribeTimeout: UInt16 = 10,
+        publishTimeout: UInt16 = 10
+    ) {
         self.keepAlive = keepAlive
         self.pingTimeout = pingTimeout
         self.connTimeout = connTimeout
         self.maxRetries = maxRetries
         self.cleanSession = cleanSession
+        self.subscribeTimeout = subscribeTimeout
+        self.publishTimeout = publishTimeout
     }
 }
 

--- a/Sources/SwiftMQTTAsync/MQTTClient/MQTTClient.swift
+++ b/Sources/SwiftMQTTAsync/MQTTClient/MQTTClient.swift
@@ -265,10 +265,6 @@ extension MQTTClient {
     }
 
     private func subscribeToTopics() async throws {
-        // let topics = await self.session.getSubscriptions()
-        // if topics.count <= 0 { return }
-
-        // try await self.subscribe(to: topics)
         let subs = await self.session.getSubscriptions()
         if subs.count <= 0 { return }
         for (properties, topicFilters) in subs {

--- a/Sources/SwiftMQTTAsync/MQTTClient/MQTTConnection.swift
+++ b/Sources/SwiftMQTTAsync/MQTTClient/MQTTConnection.swift
@@ -4,6 +4,7 @@ import NIOPosix
 actor MQTTConnection {
     private var channel: NIOAsyncChannel<ByteBuffer, ByteBuffer>?
     private let eventLoopGroup: EventLoopGroup
+    private var handler: MQTTConnectionHandler?
 
     private let host: String
     private let port: Int
@@ -12,7 +13,9 @@ actor MQTTConnection {
 
     private let eventBus: MQTTEventBus<MQTTInternalEvent>
 
-    public init(host: String, port: Int, eventBus: MQTTEventBus<MQTTInternalEvent>, version: Version) {
+    public init(
+        host: String, port: Int, eventBus: MQTTEventBus<MQTTInternalEvent>, version: Version
+    ) {
         if port <= 0 { fatalError("Invalid port number: \(port)") }
 
         self.host = host
@@ -48,7 +51,6 @@ actor MQTTConnection {
             self.eventBus.emit(.send(packet))
         }
 
-
         let bootstrap = ClientBootstrap(group: self.eventLoopGroup)
             .channelInitializer { channel in
                 channel.pipeline.addHandler(handler)
@@ -64,6 +66,7 @@ actor MQTTConnection {
             }
 
         self.channel = channel
+        self.handler = handler
     }
 
     func send(packet: any MQTTControlPacket) async throws {
@@ -73,6 +76,18 @@ actor MQTTConnection {
         buffer.writeBytes(bytes)
 
         try await channel.channel.writeAndFlush(buffer)
+    }
+
+    func schedule<T>(_ body: @escaping (ChannelHandlerContext, MQTTSession2) -> EventLoopFuture<T>)
+        async throws -> T
+    {
+        guard let channel = self.channel?.channel, let handler = self.handler else {
+            throw MQTTError.connectionError(.disconnected)
+        }
+
+        return try await channel.eventLoop.submit {
+            body(handler.context)
+        }
     }
 
     func close() async throws {

--- a/Sources/SwiftMQTTAsync/MQTTClient/MQTTConnection.swift
+++ b/Sources/SwiftMQTTAsync/MQTTClient/MQTTConnection.swift
@@ -47,10 +47,6 @@ actor MQTTConnection {
             self.eventBus.emit(.packet(packet))
         }
 
-        handler.handleSend = { packet in
-            self.eventBus.emit(.send(packet))
-        }
-
         let bootstrap = ClientBootstrap(group: self.eventLoopGroup)
             .channelInitializer { channel in
                 channel.pipeline.addHandler(handler)
@@ -76,18 +72,6 @@ actor MQTTConnection {
         buffer.writeBytes(bytes)
 
         try await channel.channel.writeAndFlush(buffer)
-    }
-
-    func schedule<T>(_ body: @escaping (ChannelHandlerContext, MQTTSession2) -> EventLoopFuture<T>)
-        async throws -> T
-    {
-        guard let channel = self.channel?.channel, let handler = self.handler else {
-            throw MQTTError.connectionError(.disconnected)
-        }
-
-        return try await channel.eventLoop.submit {
-            body(handler.context)
-        }
     }
 
     func close() async throws {

--- a/Sources/SwiftMQTTAsync/MQTTClient/MQTTConnectionHandler.swift
+++ b/Sources/SwiftMQTTAsync/MQTTClient/MQTTConnectionHandler.swift
@@ -1,25 +1,17 @@
 import NIOCore
 
-final class MQTTConnectionHandler: ChannelDuplexHandler, @unchecked Sendable {
+final class MQTTConnectionHandler: ChannelInboundHandler, @unchecked Sendable {
     typealias InboundIn = ByteBuffer
-    typealias OutboundIn = any MQTTControlPacket
-    typealias OutboundOut = ByteBuffer
 
     private var parser: PacketParser
-    private(set) var context: ChannelHandlerContext!
 
     var handleReceive: ((MQTTPacket) -> Void)?
-    var handleSend: ((any MQTTControlPacket) -> Void)?
     var handleError: ((any Error) -> Void)?
     var handleChannelActive: (() -> Void)?
     var handleChannelInactive: (() -> Void)?
 
     init(version: Version) {
         self.parser = PacketParser(version: version)
-    }
-
-    func handlerAdded(context: ChannelHandlerContext) {
-
     }
 
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
@@ -29,18 +21,6 @@ final class MQTTConnectionHandler: ChannelDuplexHandler, @unchecked Sendable {
         for packet in packets {
             handleReceive?(packet)
         }
-    }
-
-    func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
-        let packet = unwrapOutboundIn(data)
-
-        handleSend?(packet)
-
-        let bytes = packet.encode()
-        var buffer = context.channel.allocator.buffer(capacity: bytes.count)
-        buffer.writeBytes(bytes)
-
-        context.write(NIOAny(buffer), promise: promise)
     }
 
     func channelActive(context: ChannelHandlerContext) {

--- a/Sources/SwiftMQTTAsync/MQTTClient/MQTTConnectionHandler.swift
+++ b/Sources/SwiftMQTTAsync/MQTTClient/MQTTConnectionHandler.swift
@@ -1,9 +1,12 @@
 import NIOCore
 
-final class MQTTConnectionHandler: ChannelInboundHandler, @unchecked Sendable {
+final class MQTTConnectionHandler: ChannelDuplexHandler, @unchecked Sendable {
     typealias InboundIn = ByteBuffer
+    typealias OutboundIn = any MQTTControlPacket
+    typealias OutboundOut = ByteBuffer
 
     private var parser: PacketParser
+    private(set) var context: ChannelHandlerContext!
 
     var handleReceive: ((MQTTPacket) -> Void)?
     var handleSend: ((any MQTTControlPacket) -> Void)?
@@ -15,6 +18,10 @@ final class MQTTConnectionHandler: ChannelInboundHandler, @unchecked Sendable {
         self.parser = PacketParser(version: version)
     }
 
+    func handlerAdded(context: ChannelHandlerContext) {
+
+    }
+
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         let buffer = Self.unwrapInboundIn(data)
         let packets = parser.feed(buffer: buffer)
@@ -22,6 +29,18 @@ final class MQTTConnectionHandler: ChannelInboundHandler, @unchecked Sendable {
         for packet in packets {
             handleReceive?(packet)
         }
+    }
+
+    func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
+        let packet = unwrapOutboundIn(data)
+
+        handleSend?(packet)
+
+        let bytes = packet.encode()
+        var buffer = context.channel.allocator.buffer(capacity: bytes.count)
+        buffer.writeBytes(bytes)
+
+        context.write(NIOAny(buffer), promise: promise)
     }
 
     func channelActive(context: ChannelHandlerContext) {

--- a/Sources/SwiftMQTTAsync/MQTTClient/MQTTError.swift
+++ b/Sources/SwiftMQTTAsync/MQTTClient/MQTTError.swift
@@ -3,6 +3,7 @@ enum MQTTError: Error, Equatable {
     case protocolViolation(ProtocolError)
     case timeout(TimeoutKind)
     case unexpectedError(String)
+    case subscriptionRejected(TopicFilter)
 }
 
 enum ConnectionError: Error, Equatable {
@@ -22,6 +23,7 @@ enum ProtocolError: Error, Equatable {
     case unknownPacketId(packetId: UInt16)
     case invalidState(expected: String, acutal: String)
     case operationRejected(reasonCode: Byte, operation: MQTTControlPacketType)
+    case unexpectedPublish(topic: String)
 }
 
 enum MalformedPacketReason: Error, Equatable {

--- a/Sources/SwiftMQTTAsync/MQTTClient/MQTTSession.swift
+++ b/Sources/SwiftMQTTAsync/MQTTClient/MQTTSession.swift
@@ -6,8 +6,11 @@ actor MQTTSession {
 
     let commandBus: MQTTEventBus<MQTTInternalCommand>
 
-    private var subscriptions: [TopicFilter] = []
-    private var subs: [(SubscribeProperties?, [TopicFilter])] = []
+    private var inflightSubscriptions: [UInt16: ([TopicFilter], SubscribeProperties?)] = [:]
+    // topic string, qos, properties
+    private var subscriptions: [String: (QoS, SubscribeProperties?)]
+    private var inflightUnsubs: [UInt16: [String]] = [:]
+
     private var keepAliveTask: Task<Void, Never>?
     private var keepAliveCont: CheckedContinuation<Void, Never>?
 
@@ -29,9 +32,9 @@ actor MQTTSession {
         self.commandBus = commandBus
     }
 
-    func getSubscriptions() -> [(SubscribeProperties?, [TopicFilter])] {
-        // return self.subscriptions
-        return self.subs
+    func getSubscriptions() -> [([TopicFilter], SubscribeProperties?)] {
+
+        // return Array(self.subscriptions.values)
     }
 
     func handle(_ event: MQTTInternalEvent) {
@@ -39,7 +42,6 @@ actor MQTTSession {
         case .send(let packet):
             self.handleSend(packet: packet)
         case .packet(let packet):
-            self.eventBus.emit(.received(packet))
             self.handlePacket(packet: packet)
         case .connectionError(let error):
             self.eventBus.emit(.error(error))
@@ -51,6 +53,7 @@ actor MQTTSession {
     }
 
     private func handlePacket(packet: MQTTPacket) {
+        self.eventBus.emit(.received(packet))
         switch packet {
         case .puback(let puback):
             self.handlePuback(puback)
@@ -133,9 +136,9 @@ extension MQTTSession {
                         reasonCode: .malformedPacket))
                 return
             }
-            // should define separate timeout for publish in config
             let timeoutTask = TimeoutTask(
-                timeout: 10, kind: .publish(packetId: packetId, qos: .ExactlyOnce))
+                timeout: self.config.publishTimeout,
+                kind: .publish(packetId: packetId, qos: .ExactlyOnce))
             timeoutTask.start()
             self.activeTasks[packetId] = InflightTask(
                 state: .publishQoS2(.publishSent), timeout: timeoutTask)
@@ -149,7 +152,8 @@ extension MQTTSession {
             }
 
             let timeoutTask = TimeoutTask(
-                timeout: 10, kind: .publish(packetId: packetId, qos: .AtLeastOnce))
+                timeout: self.config.publishTimeout,
+                kind: .publish(packetId: packetId, qos: .AtLeastOnce))
             timeoutTask.start()
             self.activeTasks[packetId] = InflightTask(
                 state: .publishQoS1(.publishSent), timeout: timeoutTask)
@@ -160,9 +164,9 @@ extension MQTTSession {
 
     private func handleSendPubrel(_ pubrel: Pubrel) {
         let packetId = pubrel.varHeader.packetId
-        // TODO: set timout in config
         let timeoutTask = TimeoutTask(
-            timeout: 10, kind: .publish(packetId: packetId, qos: .ExactlyOnce))
+            timeout: self.config.publishTimeout,
+            kind: .publish(packetId: packetId, qos: .ExactlyOnce))
         timeoutTask.start()
         self.activeTasks[packetId] = InflightTask(
             state: .publishQoS2(.pubRelSent), timeout: timeoutTask)
@@ -205,11 +209,11 @@ extension MQTTSession {
         let packetId = subscribe.varHeader.packetId
         let topicFilters = subscribe.payload.topics
         let properties = subscribe.varHeader.properties
-        self.subscriptions.append(contentsOf: topicFilters)
-        self.subs.append((properties, topicFilters))
+        self.inflightSubscriptions[packetId] = (topicFilters, properties)
+        // register subscriptions
 
-        // TODO: Define duration in config
-        let timeoutTask = TimeoutTask(timeout: 10, kind: .subscribe(packetId: packetId))
+        let timeoutTask = TimeoutTask(
+            timeout: self.config.subscribeTimeout, kind: .subscribe(packetId: packetId))
         timeoutTask.start()
         self.activeTasks[packetId] = InflightTask(
             state: .subscribe(.SubscribeSent), timeout: timeoutTask)
@@ -229,17 +233,21 @@ extension MQTTSession {
 
     private func handleSendUnsubscribe(_ unsub: Unsubscribe) {
         let packetId = unsub.varHeader.packetId
-        // TODO: define duration in config
-        let timeoutTask = TimeoutTask(timeout: 10, kind: .unsub(packetId: packetId))
+        let timeoutTask = TimeoutTask(
+            timeout: self.config.subscribeTimeout, kind: .unsub(packetId: packetId))
         timeoutTask.start()
         self.activeTasks[packetId] = InflightTask(
             state: .unsubscribe(.unsubSent), timeout: timeoutTask)
+
+        // track inflight unsub so we can handle return codes
+        self.inflightUnsubs[packetId] = unsub.payload.topics
     }
 }
 
 // MARK: receive handlers
 extension MQTTSession {
     private func handleConnack(_ connack: Connack) {
+        self.eventBus.emit(.received(MQTTPacket.connack(connack)))
         // v3
         if let returnCode = connack.varHeader.connectReturnCode {
             if case .ConnectionAccepted = returnCode {
@@ -280,6 +288,7 @@ extension MQTTSession {
     }
 
     private func handlePingresp(_ pingresp: Pingresp) {
+        self.eventBus.emit(.received(MQTTPacket.pingresp(pingresp)))
         guard let pingrespTask = self.pingrespTask else {
             self.commandBus.emit(
                 .disconnect(
@@ -301,11 +310,49 @@ extension MQTTSession {
                     reasonCode: .protocolError))
             return
         }
+
+        self.eventBus.emit(.received(MQTTPacket.suback(suback)))
+
+        // if a sub was rejected, notify user
+        var index = 0
+
+        guard let inflightSub = self.inflightSubscriptions.removeValue(forKey: packetId) else {
+            self.commandBus.emit(
+                .disconnect(
+                    MQTTError.unexpectedError("infligt sub should exist for packetId: \(packetId)"))
+            )
+            return
+        }
+        let topics = inflightSub.0
+
+        for returnCode in suback.payload.returnCodes {
+            if case .Rejected = returnCode {
+                let topic = topics[index]
+                self.eventBus.emit(.error(MQTTError.subscriptionRejected(topic)))
+            }
+            index += 1
+        }
+
         subackTask.timeout?.stop()
     }
 
     private func handlePublish(_ publish: Publish) {
-        // TODO: check that topic is subscribed to and then emit recevive event
+        // check that topic is actually subscribed to
+        let topic = publish.variableHeader.topicName
+        if !self.inflightSubscriptions.values.contains(where: { (topicFilters, _) in
+            topicFilters.contains { $0.topic == topic }
+        }) {
+            self.commandBus.emit(
+                .disconnect(MQTTError.protocolViolation(.unexpectedPublish(topic: topic))))
+            return
+        }
+        // guard self.subscribedTopics[topic] != nil else {
+        //     self.commandBus.emit(
+        //         .disconnect(MQTTError.protocolViolation(.unexpectedPublish(topic: topic))))
+        //     return
+        // }
+        self.eventBus.emit(.received(MQTTPacket.publish(publish)))
+
         switch publish.qos {
         case .ExactlyOnce:
             guard let packetId = publish.variableHeader.packetId else {
@@ -356,6 +403,8 @@ extension MQTTSession {
             return
         }
 
+        self.eventBus.emit(.received(MQTTPacket.puback(puback)))
+
         inflightTask.timeout?.stop(with: result)
     }
 
@@ -369,6 +418,8 @@ extension MQTTSession {
             return
         }
 
+        self.eventBus.emit(.received(MQTTPacket.pubrec(pubrec)))
+
         inflightTask.timeout?.stop()
     }
 
@@ -381,6 +432,9 @@ extension MQTTSession {
                     reasonCode: .protocolError))
             return
         }
+
+        self.eventBus.emit(.received(MQTTPacket.pubrel(pubrel)))
+
         self.commandBus.emit(.send(Pubcomp(packetId: packetId)))
     }
 
@@ -394,17 +448,41 @@ extension MQTTSession {
             return
         }
 
+        self.eventBus.emit(.received(MQTTPacket.pubcomp(pubcomp)))
+
         inflighTask.timeout?.stop()
     }
 
-    // TODO: Should propably remove sub on successful unsub
     private func handleUnsuback(_ unsuback: Unsuback) {
         // v5
+        let packetId = unsuback.varHeader.packetId
+        guard let inflightTask = self.activeTasks.removeValue(forKey: packetId) else {
+            self.commandBus.emit(
+                .disconnect(
+                    MQTTError.protocolViolation(.unexpectedPacket(packet: .UNSUBACK)),
+                    reasonCode: .protocolError))
+            return
+        }
+
         var result: Result<Void, Error> = .success(())
+        guard let topics = self.inflightUnsubs.removeValue(forKey: packetId) else {
+            self.commandBus.emit(
+                .disconnect(
+                    MQTTError.unexpectedError(
+                        "inflight unsubs should contain packetId: \(packetId)")
+                ))
+            return
+        }
         if let reasonCodes = unsuback.payload?.reasonCodes {
+            // v5
+            var index = 0
             for reasonCode in reasonCodes {
                 if case .success = reasonCode {
                     result = .success(())
+
+                    // remove topic from active subscriptions
+                    let topic = topics[index]
+                    let _ = self.subscribedTopics.removeValue(forKey: topic)
                 } else {
                     let error =
                         MQTTError.protocolViolation(
@@ -414,17 +492,16 @@ extension MQTTSession {
                     result = .failure(error)
                     self.eventBus.emit(.error(error))
                 }
+                index += 1
+            }
+        } else {
+            // v3
+            for topic in topics {
+                let _ = self.subscribedTopics.removeValue(forKey: topic)
             }
         }
 
-        let packetId = unsuback.varHeader.packetId
-        guard let inflightTask = self.activeTasks.removeValue(forKey: packetId) else {
-            self.commandBus.emit(
-                .disconnect(
-                    MQTTError.protocolViolation(.unexpectedPacket(packet: .UNSUBACK)),
-                    reasonCode: .protocolError))
-            return
-        }
+        self.eventBus.emit(.received(MQTTPacket.unsuback(unsuback)))
 
         inflightTask.timeout?.stop(with: result)
     }
@@ -569,5 +646,16 @@ extension MQTTSession {
         self.keepAliveTask = nil
         guard let cont = self.keepAliveCont else { return }
         startKeepAlive(cont: cont)
+    }
+}
+
+// MARK: helpers
+extension MQTTSession {
+    private func registerSubscriptions(
+        topicFilters: [TopicFilter], properties: SubscribeProperties?
+    ) {
+        for topicFilter in topicFilters {
+            self.subscriptions[topicFilter.topic] = (topicFilter.qos, properties)
+        }
     }
 }

--- a/Sources/SwiftMQTTAsync/MQTTClient/MQTTSession.swift
+++ b/Sources/SwiftMQTTAsync/MQTTClient/MQTTSession.swift
@@ -8,7 +8,7 @@ actor MQTTSession {
 
     private var inflightSubscriptions: [UInt16: ([TopicFilter], SubscribeProperties?)] = [:]
     // topic string, qos, properties
-    private var subscriptions: [String: (QoS, SubscribeProperties?)]
+    private var subscriptions: [String: (QoS, SubscribeProperties?)] = [:]
     private var inflightUnsubs: [UInt16: [String]] = [:]
 
     private var keepAliveTask: Task<Void, Never>?
@@ -32,9 +32,19 @@ actor MQTTSession {
         self.commandBus = commandBus
     }
 
-    func getSubscriptions() -> [([TopicFilter], SubscribeProperties?)] {
+    func getSubscriptions() -> [SubscribeProperties?: [TopicFilter]] {
+        var subs: [SubscribeProperties?: [TopicFilter]] = [:]
+        for (key, value) in subscriptions {
+            let subProps = value.1
+            let topicFilter = TopicFilter(topic: key, qos: value.0)
+            if subs[subProps] == nil {
+                subs[subProps] = [topicFilter]
+            } else {
+                subs[subProps]?.append(topicFilter)
+            }
+        }
 
-        // return Array(self.subscriptions.values)
+        return subs
     }
 
     func handle(_ event: MQTTInternalEvent) {
@@ -53,7 +63,7 @@ actor MQTTSession {
     }
 
     private func handlePacket(packet: MQTTPacket) {
-        self.eventBus.emit(.received(packet))
+        // self.eventBus.emit(.received(packet))
         switch packet {
         case .puback(let puback):
             self.handlePuback(puback)
@@ -210,7 +220,10 @@ extension MQTTSession {
         let topicFilters = subscribe.payload.topics
         let properties = subscribe.varHeader.properties
         self.inflightSubscriptions[packetId] = (topicFilters, properties)
-        // register subscriptions
+        // register subscriptions before suback received, delete if suback times out or rejects sub
+        for filter in topicFilters {
+            self.subscriptions[filter.topic] = (filter.qos, properties)
+        }
 
         let timeoutTask = TimeoutTask(
             timeout: self.config.subscribeTimeout, kind: .subscribe(packetId: packetId))
@@ -328,6 +341,7 @@ extension MQTTSession {
         for returnCode in suback.payload.returnCodes {
             if case .Rejected = returnCode {
                 let topic = topics[index]
+                self.subscriptions.removeValue(forKey: topic.topic)  // remove topic from active subscriptions
                 self.eventBus.emit(.error(MQTTError.subscriptionRejected(topic)))
             }
             index += 1
@@ -339,18 +353,11 @@ extension MQTTSession {
     private func handlePublish(_ publish: Publish) {
         // check that topic is actually subscribed to
         let topic = publish.variableHeader.topicName
-        if !self.inflightSubscriptions.values.contains(where: { (topicFilters, _) in
-            topicFilters.contains { $0.topic == topic }
-        }) {
+        guard self.subscriptions[topic] != nil else {
             self.commandBus.emit(
                 .disconnect(MQTTError.protocolViolation(.unexpectedPublish(topic: topic))))
             return
         }
-        // guard self.subscribedTopics[topic] != nil else {
-        //     self.commandBus.emit(
-        //         .disconnect(MQTTError.protocolViolation(.unexpectedPublish(topic: topic))))
-        //     return
-        // }
         self.eventBus.emit(.received(MQTTPacket.publish(publish)))
 
         switch publish.qos {
@@ -482,7 +489,7 @@ extension MQTTSession {
 
                     // remove topic from active subscriptions
                     let topic = topics[index]
-                    let _ = self.subscribedTopics.removeValue(forKey: topic)
+                    let _ = self.subscriptions.removeValue(forKey: topic)
                 } else {
                     let error =
                         MQTTError.protocolViolation(
@@ -497,7 +504,7 @@ extension MQTTSession {
         } else {
             // v3
             for topic in topics {
-                let _ = self.subscribedTopics.removeValue(forKey: topic)
+                let _ = self.subscriptions.removeValue(forKey: topic)
             }
         }
 

--- a/Sources/SwiftMQTTAsync/MQTTClient/MQTTSession2.swift
+++ b/Sources/SwiftMQTTAsync/MQTTClient/MQTTSession2.swift
@@ -1,0 +1,9 @@
+import NIOCore
+
+final class MQTTSession2 {
+    private var inflightSubscriptions: [UInt16: EventLoopPromise<Suback>] = [:]
+
+    public func sendSubscribe(_ packet: Subscribe, context: ChannelHandler) async throws -> Suback {
+
+    }
+}

--- a/Sources/SwiftMQTTAsync/MQTTClient/MQTTSession2.swift
+++ b/Sources/SwiftMQTTAsync/MQTTClient/MQTTSession2.swift
@@ -1,9 +1,0 @@
-import NIOCore
-
-final class MQTTSession2 {
-    private var inflightSubscriptions: [UInt16: EventLoopPromise<Suback>] = [:]
-
-    public func sendSubscribe(_ packet: Subscribe, context: ChannelHandler) async throws -> Suback {
-
-    }
-}

--- a/Sources/SwiftMQTTAsync/MQTTPacket/Packets/Subscribe.swift
+++ b/Sources/SwiftMQTTAsync/MQTTPacket/Packets/Subscribe.swift
@@ -1,4 +1,4 @@
-public struct SubscribeProperties: Properties {
+public struct SubscribeProperties: Properties, Hashable {
     public var subscriptionIdentifier: Property?
     public var userProperties: [Property] = []
 

--- a/Sources/SwiftMQTTAsync/MQTTPacket/Property.swift
+++ b/Sources/SwiftMQTTAsync/MQTTPacket/Property.swift
@@ -1,6 +1,6 @@
 import NIOCore
 
-public struct Property: Sendable, Equatable {
+public struct Property: Sendable, Equatable, Hashable {
     public let identifier: PropertyIdentifier
     public let value: PropertyValue
 
@@ -420,7 +420,7 @@ extension Property {
     }
 }
 
-public enum PropertyValue: Sendable, Equatable {
+public enum PropertyValue: Sendable, Equatable, Hashable {
     case byte(Byte)
     case fourByteInt(UInt32)
     case twoByteInt(UInt16)

--- a/Tests/SwiftMQTTTests/MQTTClientTestsV5.swift
+++ b/Tests/SwiftMQTTTests/MQTTClientTestsV5.swift
@@ -406,6 +406,8 @@ struct MQTTClientTestsV5 {
                         packets.append(packet)
                         return packets
                     }
+                case .error(let error):
+                    print("Error: \(error)")
                 default:
                     break
                 }
@@ -424,14 +426,14 @@ struct MQTTClientTestsV5 {
             try await packetTask.value
         }
 
-        await publisher.stop()
-        await subscriber.stop()
-
         let testPublish = try! Publish(
             topicName: "test/topic1/v5", message: "hello", packetId: packetId, qos: .AtLeastOnce,
             properties: PublishProperties())
         #expect(packets[0] as? Publish == testPublish)
         #expect(packets[1] as? Puback == Puback(packetId: packetId))
+
+        await publisher.stop()
+        await subscriber.stop()
     }
 
     @Test("v5 QoS 2 publish and subscribe", .enabled(if: TestEnv.host != nil)) func v5qos2PubSub()


### PR DESCRIPTION
- **Renamed repo + lib**
- **Update README**
- **Fixed tests**
- **Refactored MQTTClient into two classes for MQTTv3 and MQTTv5, both classes use an internal MQTTClient for operations**
- **Added Property struct + Version enum**
- **Implemented v5 connect packet**
- **implemented v5 disconnect packet + added descriptive errors to property decode**
- **Implemented Properties protocol with default encode and toString implementations to get rid of duplicate implementations in every packet**
- **Decoding a packet now requires a version be specified (v3 or v5) so properties can properly be decoded, also implemented v5 publish**
- **v5 puback**
- **commit**
- **Implement v5 puback + tests**
- **Implement v5 pubcomp + tests**
- **Implement v5 pubrec + tests**
- **Implemented v5 suback + subscribe, added tests and refactored properties decoding into separate function**
- **Implemented v5 unsubscribe + added tests**
- **Implemented v5 unsuback + added tests**
- **implemented rudimentary v5 client + restructured tests into suites**
- **added connect, qos0 pub + sub and unsub to v5 client + tests**
- **implemented qos 1 and 2 publish/subscribe + disconnect for v5 client and added tests**
- **added ability to specify reasonCode in disconnect command**
- **update readme**
- **update readme**
- **intermediate commit**
- **added guards to check that topics are subscribed to before passing on publish event to client**
